### PR TITLE
feat(Item): add reviewedAt

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -43,6 +43,7 @@ type Item @entity {
   nfts: [NFT!] @derivedFrom(field: "item")
   createdAt: BigInt!
   updatedAt: BigInt!
+  reviewedAt: BigInt!
 
   # Searcheable fields
   searchText: String

--- a/src/entities/schema.ts
+++ b/src/entities/schema.ts
@@ -478,6 +478,15 @@ export class Item extends Entity {
     this.set("updatedAt", Value.fromBigInt(value));
   }
 
+  get reviewedAt(): BigInt {
+    let value = this.get("reviewedAt");
+    return value.toBigInt();
+  }
+
+  set reviewedAt(value: BigInt) {
+    this.set("reviewedAt", Value.fromBigInt(value));
+  }
+
   get searchText(): string | null {
     let value = this.get("searchText");
     if (value === null || value.kind == ValueKind.NULL) {

--- a/src/handlers/collection.ts
+++ b/src/handlers/collection.ts
@@ -138,6 +138,7 @@ export function handleAddItem(event: AddItem): void {
   item.searchIsStoreMinter = false
   item.createdAt = event.block.timestamp
   item.updatedAt = event.block.timestamp
+  item.reviewedAt = event.block.timestamp
 
   let metadata = buildItemMetadata(item)
 
@@ -405,7 +406,7 @@ export function handleSetApproved(event: SetApproved): void {
     let item = Item.load(id)
 
     item.searchIsCollectionApproved = event.params._newValue
-
+    item.reviewedAt = event.block.timestamp
     item.save()
   }
 


### PR DESCRIPTION
Added `reviewedAt` to `Item` schema. Currently the server is returning the items by creation time, but since items might be approved way later than they were submitted for review, they don't end up on the first page of the marketplace once they are approved by the reviewer. Also it makes the marketplace look glitchy, since sometimes you see new items appear but they are not at the beginning of the page. This new property will allow us to show the items sorted as they are approved by the reviewers.

Deployed to Mumbai: https://thegraph.com/legacy-explorer/subgraph/decentraland/collections-matic-mumbai