### PR TITLE
feat: mints

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -264,6 +264,6 @@ type Mint @entity {
   searchContractAddress: String!
   searchItemId: BigInt!
   searchTokenId: BigInt!
-  searchIssuedId: BigInt!
+  searchIssuedId: BigInt
   searchIsStoreMinter: Boolean!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -240,3 +240,25 @@ type Count @entity {
   nftTotal: Int!
   started: Int!
 }
+
+# ---------------------------------------------------------
+# Mints ---------------------------------------------------
+# ---------------------------------------------------------
+
+type Mint @entity {
+  id: ID!
+
+  item: Item!
+  nft: NFT!
+
+  beneficiary: String!
+  minter: String!
+  timestamp: BigInt!
+
+  searchPrice: BigInt!
+  searchContractAddress: String!
+  searchItemId: BigInt!
+  searchTokenId: BigInt!
+  searchIssuedId: BigInt!
+  searchIsStoreMinter: Boolean!
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -238,6 +238,10 @@ type Count @entity {
   collectionTotal: Int!
   itemTotal: Int!
   nftTotal: Int!
+  primarySalesTotal: Int!
+  primarySalesManaTotal: BigInt!
+  secondarySalesTotal: Int!
+  secondarySalesManaTotal: BigInt!
   started: Int!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -235,6 +235,7 @@ type Bid @entity {
 type Count @entity {
   id: ID!
   orderTotal: Int!
+  bidTotal: Int!
   collectionTotal: Int!
   itemTotal: Int!
   nftTotal: Int!

--- a/schema.graphql
+++ b/schema.graphql
@@ -259,7 +259,7 @@ type Mint @entity {
   minter: String!
   timestamp: BigInt!
 
-  searchPrice: BigInt!
+  searchPrimarySalePrice: BigInt
   searchContractAddress: String!
   searchItemId: BigInt!
   searchTokenId: BigInt!

--- a/src/entities/schema.ts
+++ b/src/entities/schema.ts
@@ -1700,6 +1700,42 @@ export class Count extends Entity {
     this.set("nftTotal", Value.fromI32(value));
   }
 
+  get primarySalesTotal(): i32 {
+    let value = this.get("primarySalesTotal");
+    return value.toI32();
+  }
+
+  set primarySalesTotal(value: i32) {
+    this.set("primarySalesTotal", Value.fromI32(value));
+  }
+
+  get primarySalesManaTotal(): BigInt {
+    let value = this.get("primarySalesManaTotal");
+    return value.toBigInt();
+  }
+
+  set primarySalesManaTotal(value: BigInt) {
+    this.set("primarySalesManaTotal", Value.fromBigInt(value));
+  }
+
+  get secondarySalesTotal(): i32 {
+    let value = this.get("secondarySalesTotal");
+    return value.toI32();
+  }
+
+  set secondarySalesTotal(value: i32) {
+    this.set("secondarySalesTotal", Value.fromI32(value));
+  }
+
+  get secondarySalesManaTotal(): BigInt {
+    let value = this.get("secondarySalesManaTotal");
+    return value.toBigInt();
+  }
+
+  set secondarySalesManaTotal(value: BigInt) {
+    this.set("secondarySalesManaTotal", Value.fromBigInt(value));
+  }
+
   get started(): i32 {
     let value = this.get("started");
     return value.toI32();

--- a/src/entities/schema.ts
+++ b/src/entities/schema.ts
@@ -1874,13 +1874,21 @@ export class Mint extends Entity {
     this.set("searchTokenId", Value.fromBigInt(value));
   }
 
-  get searchIssuedId(): BigInt {
+  get searchIssuedId(): BigInt | null {
     let value = this.get("searchIssuedId");
-    return value.toBigInt();
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
   }
 
-  set searchIssuedId(value: BigInt) {
-    this.set("searchIssuedId", Value.fromBigInt(value));
+  set searchIssuedId(value: BigInt | null) {
+    if (value === null) {
+      this.unset("searchIssuedId");
+    } else {
+      this.set("searchIssuedId", Value.fromBigInt(value as BigInt));
+    }
   }
 
   get searchIsStoreMinter(): boolean {

--- a/src/entities/schema.ts
+++ b/src/entities/schema.ts
@@ -1709,3 +1709,133 @@ export class Count extends Entity {
     this.set("started", Value.fromI32(value));
   }
 }
+
+export class Mint extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id !== null, "Cannot save Mint entity without an ID");
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save Mint entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("Mint", id.toString(), this);
+  }
+
+  static load(id: string): Mint | null {
+    return store.get("Mint", id) as Mint | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get item(): string {
+    let value = this.get("item");
+    return value.toString();
+  }
+
+  set item(value: string) {
+    this.set("item", Value.fromString(value));
+  }
+
+  get nft(): string {
+    let value = this.get("nft");
+    return value.toString();
+  }
+
+  set nft(value: string) {
+    this.set("nft", Value.fromString(value));
+  }
+
+  get beneficiary(): string {
+    let value = this.get("beneficiary");
+    return value.toString();
+  }
+
+  set beneficiary(value: string) {
+    this.set("beneficiary", Value.fromString(value));
+  }
+
+  get minter(): string {
+    let value = this.get("minter");
+    return value.toString();
+  }
+
+  set minter(value: string) {
+    this.set("minter", Value.fromString(value));
+  }
+
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
+    return value.toBigInt();
+  }
+
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
+  }
+
+  get searchPrice(): BigInt {
+    let value = this.get("searchPrice");
+    return value.toBigInt();
+  }
+
+  set searchPrice(value: BigInt) {
+    this.set("searchPrice", Value.fromBigInt(value));
+  }
+
+  get searchContractAddress(): string {
+    let value = this.get("searchContractAddress");
+    return value.toString();
+  }
+
+  set searchContractAddress(value: string) {
+    this.set("searchContractAddress", Value.fromString(value));
+  }
+
+  get searchItemId(): BigInt {
+    let value = this.get("searchItemId");
+    return value.toBigInt();
+  }
+
+  set searchItemId(value: BigInt) {
+    this.set("searchItemId", Value.fromBigInt(value));
+  }
+
+  get searchTokenId(): BigInt {
+    let value = this.get("searchTokenId");
+    return value.toBigInt();
+  }
+
+  set searchTokenId(value: BigInt) {
+    this.set("searchTokenId", Value.fromBigInt(value));
+  }
+
+  get searchIssuedId(): BigInt {
+    let value = this.get("searchIssuedId");
+    return value.toBigInt();
+  }
+
+  set searchIssuedId(value: BigInt) {
+    this.set("searchIssuedId", Value.fromBigInt(value));
+  }
+
+  get searchIsStoreMinter(): boolean {
+    let value = this.get("searchIsStoreMinter");
+    return value.toBoolean();
+  }
+
+  set searchIsStoreMinter(value: boolean) {
+    this.set("searchIsStoreMinter", Value.fromBoolean(value));
+  }
+}

--- a/src/entities/schema.ts
+++ b/src/entities/schema.ts
@@ -1821,13 +1821,21 @@ export class Mint extends Entity {
     this.set("timestamp", Value.fromBigInt(value));
   }
 
-  get searchPrice(): BigInt {
-    let value = this.get("searchPrice");
-    return value.toBigInt();
+  get searchPrimarySalePrice(): BigInt | null {
+    let value = this.get("searchPrimarySalePrice");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
   }
 
-  set searchPrice(value: BigInt) {
-    this.set("searchPrice", Value.fromBigInt(value));
+  set searchPrimarySalePrice(value: BigInt | null) {
+    if (value === null) {
+      this.unset("searchPrimarySalePrice");
+    } else {
+      this.set("searchPrimarySalePrice", Value.fromBigInt(value as BigInt));
+    }
   }
 
   get searchContractAddress(): string {

--- a/src/entities/schema.ts
+++ b/src/entities/schema.ts
@@ -1673,6 +1673,15 @@ export class Count extends Entity {
     this.set("orderTotal", Value.fromI32(value));
   }
 
+  get bidTotal(): i32 {
+    let value = this.get("bidTotal");
+    return value.toI32();
+  }
+
+  set bidTotal(value: i32) {
+    this.set("bidTotal", Value.fromI32(value));
+  }
+
   get collectionTotal(): i32 {
     let value = this.get("collectionTotal");
     return value.toI32();

--- a/src/handlers/bid.ts
+++ b/src/handlers/bid.ts
@@ -8,7 +8,7 @@ import { Bid, NFT } from '../entities/schema'
 import { getNFTId } from '../modules/NFT'
 import * as status from '../modules/Order'
 import { getBidId } from '../modules/Bid'
-import { buildCountFromSecondarySale } from '../modules/Count'
+import { buildCountFromBid, buildCountFromSecondarySale } from '../modules/Count'
 
 export function handleBidCreated(event: BidCreated): void {
   let nftId = getNFTId(
@@ -47,6 +47,10 @@ export function handleBidCreated(event: BidCreated): void {
 
   nft.updatedAt = event.block.timestamp
   nft.save()
+
+  // count bid
+  let count = buildCountFromBid()
+  count.save()
 }
 
 export function handleBidAccepted(event: BidAccepted): void {

--- a/src/handlers/bid.ts
+++ b/src/handlers/bid.ts
@@ -8,7 +8,7 @@ import { Bid, NFT } from '../entities/schema'
 import { getNFTId } from '../modules/NFT'
 import * as status from '../modules/Order'
 import { getBidId } from '../modules/Bid'
-import { buildCount } from '../modules/Count'
+import { buildCountFromSecondarySale } from '../modules/Count'
 
 export function handleBidCreated(event: BidCreated): void {
   let nftId = getNFTId(
@@ -76,9 +76,7 @@ export function handleBidAccepted(event: BidAccepted): void {
   nft.save()
 
   // count secondary sale
-  let count = buildCount()
-  count.secondarySalesTotal += 1
-  count.secondarySalesManaTotal = count.secondarySalesManaTotal.plus(bid.price)
+  let count = buildCountFromSecondarySale(bid.price)
   count.save()
 }
 

--- a/src/handlers/bid.ts
+++ b/src/handlers/bid.ts
@@ -8,6 +8,7 @@ import { Bid, NFT } from '../entities/schema'
 import { getNFTId } from '../modules/NFT'
 import * as status from '../modules/Order'
 import { getBidId } from '../modules/Bid'
+import { buildCount } from '../modules/Count'
 
 export function handleBidCreated(event: BidCreated): void {
   let nftId = getNFTId(
@@ -73,6 +74,12 @@ export function handleBidAccepted(event: BidAccepted): void {
 
   nft.updatedAt = event.block.timestamp
   nft.save()
+
+  // count secondary sale
+  let count = buildCount()
+  count.secondarySalesTotal += 1
+  count.secondarySalesManaTotal = count.secondarySalesManaTotal.plus(bid.price)
+  count.save()
 }
 
 export function handleBidCancelled(event: BidCancelled): void {

--- a/src/handlers/marketplace.ts
+++ b/src/handlers/marketplace.ts
@@ -10,7 +10,7 @@ import {
   updateNFTOrderProperties,
   cancelActiveOrder
 } from '../modules/NFT'
-import { buildCount, buildCountFromOrder } from '../modules/Count'
+import { buildCountFromOrder, buildCountFromSecondarySale } from '../modules/Count'
 import * as status from '../modules/Order'
 
 export function handleOrderCreated(event: OrderCreated): void {
@@ -80,9 +80,7 @@ export function handleOrderSuccessful(event: OrderSuccessful): void {
   nft.save()
 
   // count secondary sale
-  let count = buildCount()
-  count.secondarySalesTotal += 1
-  count.secondarySalesManaTotal = count.secondarySalesManaTotal.plus(order.price)
+  let count = buildCountFromSecondarySale(order.price)
   count.save()
 }
 

--- a/src/handlers/marketplace.ts
+++ b/src/handlers/marketplace.ts
@@ -10,7 +10,7 @@ import {
   updateNFTOrderProperties,
   cancelActiveOrder
 } from '../modules/NFT'
-import { buildCountFromOrder } from '../modules/Count'
+import { buildCount, buildCountFromOrder } from '../modules/Count'
 import * as status from '../modules/Order'
 
 export function handleOrderCreated(event: OrderCreated): void {
@@ -78,6 +78,12 @@ export function handleOrderSuccessful(event: OrderSuccessful): void {
   nft.updatedAt = event.block.timestamp
   nft = updateNFTOrderProperties(nft!, order!)
   nft.save()
+
+  // count secondary sale
+  let count = buildCount()
+  count.secondarySalesTotal += 1
+  count.secondarySalesManaTotal = count.secondarySalesManaTotal.plus(order.price)
+  count.save()
 }
 
 export function handleOrderCancelled(event: OrderCancelled): void {

--- a/src/handlers/nft.ts
+++ b/src/handlers/nft.ts
@@ -93,7 +93,9 @@ export function handleMintNFT(
   mint.beneficiary = nft.owner
   mint.minter = minterAddress
   mint.timestamp = event.block.timestamp
-  mint.searchPrice = item.price
+  if (isStoreMinter) {
+    mint.searchPrimarySalePrice = item.price
+  }
   mint.searchContractAddress = nft.contractAddress
   mint.searchTokenId = nft.tokenId
   mint.searchItemId = item.blockchainId

--- a/src/handlers/nft.ts
+++ b/src/handlers/nft.ts
@@ -93,21 +93,21 @@ export function handleMintNFT(
   mint.beneficiary = nft.owner
   mint.minter = minterAddress
   mint.timestamp = event.block.timestamp
-  if (isStoreMinter) {
-    mint.searchPrimarySalePrice = item.price
-  }
   mint.searchContractAddress = nft.contractAddress
   mint.searchTokenId = nft.tokenId
   mint.searchItemId = item.blockchainId
   mint.searchIssuedId = issuedId
   mint.searchIsStoreMinter = isStoreMinter
-  mint.save()
+  
 
   // count primary sale
   if (isStoreMinter) {
+    mint.searchPrimarySalePrice = item.price
     let count = buildCountFromPrimarySale(item.price)
     count.save()
   }
+
+  mint.save()
 }
 
 export function handleTransferNFT(event: Transfer): void {

--- a/src/handlers/nft.ts
+++ b/src/handlers/nft.ts
@@ -28,7 +28,7 @@ import {
   buildCountFromCollection,
   buildCountFromNFT,
   buildCountFromItem,
-  buildCount,
+  buildCountFromPrimarySale,
 } from '../modules/Count'
 import {
   Issue,
@@ -105,9 +105,7 @@ export function handleMintNFT(
 
   // count primary sale
   if (isStoreMinter) {
-    let count = buildCount()
-    count.primarySalesTotal += 1
-    count.primarySalesManaTotal = count.primarySalesManaTotal.plus(item.price)
+    let count = buildCountFromPrimarySale(item.price)
     count.save()
   }
 }

--- a/src/handlers/nft.ts
+++ b/src/handlers/nft.ts
@@ -86,7 +86,7 @@ export function handleMintNFT(
 
   // store mint data
   let minterAddress = event.params._caller.toHexString()
-  let isStoreMinter = minterAddress === getStoreAddress()
+  let isStoreMinter = minterAddress == getStoreAddress()
   let mint = new Mint(nftId)
   mint.nft = nft.id
   mint.item = item.id

--- a/src/handlers/nft.ts
+++ b/src/handlers/nft.ts
@@ -257,6 +257,20 @@ export function handleTransferWearableV1(event: ERC721Transfer): void {
     item.totalSupply = item.totalSupply.plus(BigInt.fromI32(1))
 
     item.save()
+
+    // store mint
+    let mint = new Mint(id)
+    mint.nft = nft.id
+    mint.item = item.id
+    mint.beneficiary = nft.owner
+    mint.minter = event.transaction.from.toHexString()
+    mint.timestamp = event.block.timestamp
+    mint.searchContractAddress = nft.contractAddress
+    mint.searchTokenId = nft.tokenId
+    mint.searchItemId = item.blockchainId
+    mint.searchIssuedId = nft.issuedId
+    mint.searchIsStoreMinter = false
+    mint.save()
   } else {
     let oldNFT = NFT.load(id)
     if (cancelActiveOrder(oldNFT!, event.block.timestamp)) {

--- a/src/modules/count/index.ts
+++ b/src/modules/count/index.ts
@@ -63,7 +63,7 @@ export function buildCountFromBid(): Count {
   return count
 }
 
-export function buildCountFromPrimarySale(price: BigInt) {
+export function buildCountFromPrimarySale(price: BigInt): Count {
   let count = buildCount()
   count.primarySalesTotal += 1
   count.primarySalesManaTotal = count.primarySalesManaTotal.plus(price)
@@ -71,7 +71,7 @@ export function buildCountFromPrimarySale(price: BigInt) {
 }
 
 
-export function buildCountFromSecondarySale(price: BigInt) {
+export function buildCountFromSecondarySale(price: BigInt): Count {
   let count = buildCount()
   count.secondarySalesTotal += 1
   count.secondarySalesManaTotal = count.secondarySalesManaTotal.plus(price)

--- a/src/modules/count/index.ts
+++ b/src/modules/count/index.ts
@@ -9,6 +9,7 @@ export function buildCount(): Count {
   if (count == null) {
     count = new Count(DEFAULT_ID)
     count.orderTotal = 0
+    count.bidTotal = 0
     count.collectionTotal = 0
     count.itemTotal = 0
     count.nftTotal = 0
@@ -50,6 +51,14 @@ export function buildCountFromOrder(): Count {
   let count = buildCount()
 
   count.orderTotal += 1
+
+  return count
+}
+
+export function buildCountFromBid(): Count {
+  let count = buildCount()
+
+  count.bidTotal += 1
 
   return count
 }

--- a/src/modules/count/index.ts
+++ b/src/modules/count/index.ts
@@ -1,3 +1,4 @@
+import { BigInt } from '@graphprotocol/graph-ts'
 import { Count } from '../../entities/schema'
 
 export const DEFAULT_ID = 'all'
@@ -11,6 +12,10 @@ export function buildCount(): Count {
     count.collectionTotal = 0
     count.itemTotal = 0
     count.nftTotal = 0
+    count.primarySalesTotal = 0
+    count.primarySalesManaTotal = BigInt.fromI32(0);
+    count.secondarySalesTotal = 0
+    count.secondarySalesManaTotal = BigInt.fromI32(0);
     count.started = 0
   }
 

--- a/src/modules/count/index.ts
+++ b/src/modules/count/index.ts
@@ -53,3 +53,18 @@ export function buildCountFromOrder(): Count {
 
   return count
 }
+
+export function buildCountFromPrimarySale(price: BigInt) {
+  let count = buildCount()
+  count.primarySalesTotal += 1
+  count.primarySalesManaTotal = count.primarySalesManaTotal.plus(price)
+  return count
+}
+
+
+export function buildCountFromSecondarySale(price: BigInt) {
+  let count = buildCount()
+  count.secondarySalesTotal += 1
+  count.secondarySalesManaTotal = count.secondarySalesManaTotal.plus(price)
+  return count
+}


### PR DESCRIPTION
This PR adds a `Mint` entity that tracks each mint. If the mint was done by the `Store` the mint will be flagged with a `searchIsStoreMinter` prop (which means it was a primary sale).

The entity also has a reference to the `item` and the particular `nft ` minted, some data about the mint event itself (`beneficiary`, `minter` and `timestamp`) and some search props that I though would be useful, like the `price`, `contractAddress`, `tokenId`, `itemId` and `issuedId`.

I also added some props to the global count: `primarySalesTotal`, `primarySalesManaTotal`, `secondarySalesTotal`, `secondarySalesManaTotal`.

Mumbai: https://thegraph.com/legacy-explorer/subgraph/decentraland/collections-matic-mumbai