### PR TITLE
feat: replaces Play Mode Enum for a loop Boolean field

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 - Mainnet: https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-mainnet (QmWrLR11uq12yDD7qUFzeyYEFXxQiU2UcKFYZLrccCYkwk)
 - Ropsten: https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-ropsten (QmbkYp3VQAvfMqsnYdNhbgYRxJ14mkBF2PnhAVLvs21asT)
 - Goerli: https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli (QmSjgZDY25SNr3kW6bsQWcSeh3NRoojtbrMSrXvKz4BsvJ)
-- Matic: https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet (QmaPNpL5oB4NjrTFmWAE4CesMjfhjouCigwptNz7x9i8cD)
-- Mumbai: https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mumbai (Qma85E3D6TabkGHaK8YzzMnbDhq1D37LGreVZSvL2yjQNp)
+- Matic: https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet (QmQAZp71zgsdaqQqeBmgU2MhxNfS44ioeCJXP9kmt3Sa5c)
+- Matic-temp: https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet-temp (QmaPNpL5oB4NjrTFmWAE4CesMjfhjouCigwptNz7x9i8cD)
+- Mumbai: https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mumbai (Qmebs8WsrLs23pQ2oCZggVFN5raZffPx5Auqh1K1pr7iQQ)
 
 ### Install
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -71,7 +71,7 @@ type Item @entity {
 
   ## Emote search fields
   searchEmoteCategory: EmoteCategory
-  searchEmotePlayMode: EmotePlayMode
+  searchEmoteLoop: Boolean
   searchEmoteRarity: String # We're using String instead of WearableRarity here so we can later query this field via ()_in
   searchEmoteBodyShapes: [WearableBodyShape!]
 
@@ -122,7 +122,7 @@ type NFT @entity {
 
   ## Emote search fields
   searchEmoteCategory: EmoteCategory
-  searchEmotePlayMode: EmotePlayMode
+  searchEmoteLoop: Boolean
   searchEmoteRarity: String # We're using String instead of WearableRarity here so we can later query this field via ()_in
   searchEmoteBodyShapes: [WearableBodyShape!]
 
@@ -164,7 +164,7 @@ type Emote @entity {
   description: String!
   collection: String!
   category: EmoteCategory!
-  playMode: EmotePlayMode!
+  loop: Boolean!
   rarity: WearableRarity!
   bodyShapes: [WearableBodyShape!]
 }
@@ -197,11 +197,6 @@ enum EmoteCategory @entity {
   reactions
   horror
   miscellaneous
-}
-
-enum EmotePlayMode @entity {
-  simple
-  loop
 }
 
 enum WearableRarity @entity {

--- a/src/entities/schema.ts
+++ b/src/entities/schema.ts
@@ -650,21 +650,13 @@ export class Item extends Entity {
     }
   }
 
-  get searchEmotePlayMode(): string | null {
-    let value = this.get("searchEmotePlayMode");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
+  get searchEmoteLoop(): boolean {
+    let value = this.get("searchEmoteLoop");
+    return value!.toBoolean();
   }
 
-  set searchEmotePlayMode(value: string | null) {
-    if (!value) {
-      this.unset("searchEmotePlayMode");
-    } else {
-      this.set("searchEmotePlayMode", Value.fromString(<string>value));
-    }
+  set searchEmoteLoop(value: boolean) {
+    this.set("searchEmoteLoop", Value.fromBoolean(value));
   }
 
   get searchEmoteRarity(): string | null {
@@ -1146,21 +1138,13 @@ export class NFT extends Entity {
     }
   }
 
-  get searchEmotePlayMode(): string | null {
-    let value = this.get("searchEmotePlayMode");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
+  get searchEmoteLoop(): boolean {
+    let value = this.get("searchEmoteLoop");
+    return value!.toBoolean();
   }
 
-  set searchEmotePlayMode(value: string | null) {
-    if (!value) {
-      this.unset("searchEmotePlayMode");
-    } else {
-      this.set("searchEmotePlayMode", Value.fromString(<string>value));
-    }
+  set searchEmoteLoop(value: boolean) {
+    this.set("searchEmoteLoop", Value.fromBoolean(value));
   }
 
   get searchEmoteRarity(): string | null {
@@ -1505,13 +1489,13 @@ export class Emote extends Entity {
     this.set("category", Value.fromString(value));
   }
 
-  get playMode(): string {
-    let value = this.get("playMode");
-    return value!.toString();
+  get loop(): boolean {
+    let value = this.get("loop");
+    return value!.toBoolean();
   }
 
-  set playMode(value: string) {
-    this.set("playMode", Value.fromString(value));
+  set loop(value: boolean) {
+    this.set("loop", Value.fromBoolean(value));
   }
 
   get rarity(): string {

--- a/src/modules/metadata/emote/index.ts
+++ b/src/modules/metadata/emote/index.ts
@@ -26,7 +26,7 @@ export function buildEmoteItem(item: Item): Emote | null {
     emote.rarity = item.rarity
     emote.category = isValidEmoteCategory(data[4]) ? data[4] : DANCE // We're using DANCE as fallback to support the emotes that were created with the old categories.
     emote.bodyShapes = data[5].split(',') // Could be more than one
-    emote.playMode = data.length == 9 && isValidEmotePlayMode(data[6]) ? data[6] : SIMPLE // Fallback the emotes without playMode to SIMPLE since LOOP wasn't allowed before.
+    emote.loop = data.length == 9 && isValidLoopValue(data[6]) && data[6] == '1' ? true : false // Fallback old emotes as not loopable
     emote.save()
 
     return emote
@@ -54,12 +54,12 @@ function isValidEmoteCategory(category: string): boolean {
   return false
 }
 
-function isValidEmotePlayMode(playMode: string): boolean {
-  if (playMode == SIMPLE || playMode === LOOP) {
+function isValidLoopValue(value: string): boolean {
+  if (value == '0' || value === '1') {
     return true
   }
 
-  log.error('Invalid emote play mode {}', [playMode])
+  log.error('Invalid emote loop value {}', [value])
 
   return false
 }
@@ -74,7 +74,7 @@ export function setItemEmoteSearchFields(item: Item): Item {
     if (emote != null) {
       item.searchText = toLowerCase(emote.name + ' ' + emote.description)
       item.searchEmoteCategory = emote.category
-      item.searchEmotePlayMode = emote.playMode
+      item.searchEmoteLoop = emote.loop
       item.searchEmoteBodyShapes = emote.bodyShapes
       item.searchEmoteRarity = emote.rarity
     }
@@ -94,7 +94,7 @@ export function setNFTEmoteSearchFields(nft: NFT): NFT {
     if (emote) {
       nft.searchText = toLowerCase(emote.name + ' ' + emote.description)
       nft.searchEmoteCategory = emote.category
-      nft.searchEmotePlayMode = emote.playMode
+      nft.searchEmoteLoop = emote.loop
       nft.searchEmoteBodyShapes = emote.bodyShapes
       nft.searchEmoteRarity = emote.rarity
     }


### PR DESCRIPTION
As we discussed, it's preferred to store a number in the contract rather than `loop` or `simple`. It's cheaper and it's not worth to have an enum for something that is highly unprovable to be extended.