### PR TITLE
fix: total dao earnings was missing publication fee

### DIFF
--- a/src/handlers/collection.ts
+++ b/src/handlers/collection.ts
@@ -164,8 +164,9 @@ export function handleAddItem(event: AddItem): void {
   item = setItemSearchFields(item)
   item.save()
 
-  let metric = buildCountFromItem()
-  metric.save()
+  let count = buildCountFromItem()
+  count.daoEarningsManaTotal = count.daoEarningsManaTotal.plus(creationFee)
+  count.save()
 
   // tracks the number of items created by the creator and fees to DAO
   let analyticsDayData = getOrCreateAnalyticsDayData(event.block.timestamp)


### PR DESCRIPTION
The `creationFee` was only included in the daily analytics but not in the total ones.