### PR TITLE
feat: Deploy commit a868abbebfbdcf7aeb1158f54aca440cb937b802 to goerli hosted and satsuma

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 |Network|URL|Current|Previous|
 |-|-|-|-|
 |Mainnet (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-ethereum-mainnet/playground|QmXAJWxr83ff8yqZkK8NrWUxETRHyXbq69sy2bmQznT136|-|
-|Mainnet (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-mainnet |QmXAJWxr83ff8yqZkK8NrWUxETRHyXbq69sy2bmQznT136|QmWrLR11uq12yDD7qUFzeyYEFXxQiU2UcKFYZLrccCYkwk|
-|Goerli (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmXbmCWShvjizcePNj2BqxqsWxdb4sxK83RvDeF1gFcFDG|QmSjgZDY25SNr3kW6bsQWcSeh3NRoojtbrMSrXvKz4BsvJ|
+|Mainnet (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-mainnet|QmXAJWxr83ff8yqZkK8NrWUxETRHyXbq69sy2bmQznT136|QmWrLR11uq12yDD7qUFzeyYEFXxQiU2UcKFYZLrccCYkwk|
+|Goerli (Satsuma)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmRbsXQDYGF4MEFsbjfbKegGyo36VXKAwcwHEiqLvwzsdS|-|
+|Goerli (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmRbsXQDYGF4MEFsbjfbKegGyo36VXKAwcwHEiqLvwzsdS|QmXbmCWShvjizcePNj2BqxqsWxdb4sxK83RvDeF1gFcFDG|
 |Matic (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-matic-mainnet/playground|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|Qmc1XwMPmbVNCqvbTkTNWxGogcZLxQ72WwTsgHVbRTJ7XD|
 |Matic (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|Qmc1XwMPmbVNCqvbTkTNWxGogcZLxQ72WwTsgHVbRTJ7XD|
 |Matic Temp (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet-temp|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|QmNrxac6yGrZWKwYLNSFagwRcGEmHUeurwfVyfYppzAs6x|


### PR DESCRIPTION
The last deployment of goerli subgraphs was for commit https://github.com/decentraland/collections-graph/commit/dfd232478af5a30e22407b5424e3b8da974098f5

Current matic deployments have been deployed from https://github.com/decentraland/collections-graph/commit/a868abbebfbdcf7aeb1158f54aca440cb937b802 so goerli subgraphs were changed to that.

ethereum mainnet subgraph should also be updated.