### PR TITLE
fix: marketplace v1 address missing for goerli config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 |-|-|-|-|
 |Mainnet (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-ethereum-mainnet/playground|QmXAJWxr83ff8yqZkK8NrWUxETRHyXbq69sy2bmQznT136|-|
 |Mainnet (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-mainnet|QmXAJWxr83ff8yqZkK8NrWUxETRHyXbq69sy2bmQznT136|QmWrLR11uq12yDD7qUFzeyYEFXxQiU2UcKFYZLrccCYkwk|
-|Goerli (Satsuma)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmRbsXQDYGF4MEFsbjfbKegGyo36VXKAwcwHEiqLvwzsdS|-|
-|Goerli (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmRbsXQDYGF4MEFsbjfbKegGyo36VXKAwcwHEiqLvwzsdS|QmXbmCWShvjizcePNj2BqxqsWxdb4sxK83RvDeF1gFcFDG|
+|Goerli (Satsuma)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmbL8a1aMAuKoMZKNjjP2pzyekFqb6AdRWji3nsPnQkEoo|QmRbsXQDYGF4MEFsbjfbKegGyo36VXKAwcwHEiqLvwzsdS|
+|Goerli (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmPtETAfzq2eCJ3U7HsS5ugC7L4WK4oNZ6RaNkYoKZZbZL|QmRbsXQDYGF4MEFsbjfbKegGyo36VXKAwcwHEiqLvwzsdS|
 |Matic (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-matic-mainnet/playground|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|Qmc1XwMPmbVNCqvbTkTNWxGogcZLxQ72WwTsgHVbRTJ7XD|
 |Matic (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|Qmc1XwMPmbVNCqvbTkTNWxGogcZLxQ72WwTsgHVbRTJ7XD|
 |Matic Temp (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet-temp|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|QmNrxac6yGrZWKwYLNSFagwRcGEmHUeurwfVyfYppzAs6x|

--- a/config/goerli.json
+++ b/config/goerli.json
@@ -10,7 +10,7 @@
   "startBlock_old_committee": 7103734,
   "address_committee": "0x0000000000000000000000000000000000000000",
   "startBlock_committee": 7103734,
-  "address_marketplace": "0x0000000000000000000000000000000000000000",
+  "address_marketplace": "0x5d01fbD3E22892be40F69bdAE7Ad921C8cdA2085",
   "startBlock_marketplace": 7103734,
   "address_marketplace_V2": "0x0000000000000000000000000000000000000000",
   "startBlock_marketplace_V2": 7103734,


### PR DESCRIPTION
The `collections-ethereum-goerli` graph is currently not tracking any orders since it's doesn't have the marketplace contract set. 

Right now the query for all the orders returns an empty array:
![image](https://user-images.githubusercontent.com/8763687/232938351-224829e4-018a-424d-91db-56db145c585e.png)
