### PR TITLE
feat: add "item" to order entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 |Network|URL|Current|Previous|
 |-|-|-|-|
-|Mainnet (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-ethereum-mainnet/playground|QmXAJWxr83ff8yqZkK8NrWUxETRHyXbq69sy2bmQznT136|-|
-|Mainnet (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-mainnet|QmXAJWxr83ff8yqZkK8NrWUxETRHyXbq69sy2bmQznT136|QmWrLR11uq12yDD7qUFzeyYEFXxQiU2UcKFYZLrccCYkwk|
-|Goerli (Satsuma)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmbL8a1aMAuKoMZKNjjP2pzyekFqb6AdRWji3nsPnQkEoo|QmRbsXQDYGF4MEFsbjfbKegGyo36VXKAwcwHEiqLvwzsdS|
-|Goerli (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmPtETAfzq2eCJ3U7HsS5ugC7L4WK4oNZ6RaNkYoKZZbZL|QmRbsXQDYGF4MEFsbjfbKegGyo36VXKAwcwHEiqLvwzsdS|
-|Matic (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-matic-mainnet/playground|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|Qmc1XwMPmbVNCqvbTkTNWxGogcZLxQ72WwTsgHVbRTJ7XD|
-|Matic (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|Qmc1XwMPmbVNCqvbTkTNWxGogcZLxQ72WwTsgHVbRTJ7XD|
-|Matic Temp (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet-temp|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|QmNrxac6yGrZWKwYLNSFagwRcGEmHUeurwfVyfYppzAs6x|
-|Mumbai (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-matic-mumbai/playground|QmQRwsc2CCebd4KVHNVeTcLZacqc3PGU5gt6yEo1n19x7L|-|
-|Mumbai (Hosted Service)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mumbai|QmQRwsc2CCebd4KVHNVeTcLZacqc3PGU5gt6yEo1n19x7L|QmfZsAg5pbMBpwY1WuDR7QPfUZ3oNEkNagVXcQ42nKX1C5|
+|Mainnet (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-ethereum-mainnet/playground|Qmf1ouGZcxBegEWodVy5fjFYFgQaB7wzw7j5rHwLcKeSXB|QmXAJWxr83ff8yqZkK8NrWUxETRHyXbq69sy2bmQznT136|
+|Mainnet (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-mainnet|QmPjcwU1HSxWAf9sMyAag6NGSYxP2Y2U2PAx4sPg15mmJZ|QmXAJWxr83ff8yqZkK8NrWUxETRHyXbq69sy2bmQznT136|
+|Goerli (Satsuma)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmSSzDJBxX7Kj4EqszCUw3AHiznkt5W1fJEpLhiTsVdaqN|QmbL8a1aMAuKoMZKNjjP2pzyekFqb6AdRWji3nsPnQkEoo|
+|Goerli (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-goerli|QmTNQHzovP1WLp1zBmJvU72uRpHhmzeHe1wb1hwysaXx6F|QmPtETAfzq2eCJ3U7HsS5ugC7L4WK4oNZ6RaNkYoKZZbZL|
+|Matic (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-matic-mainnet/playground|Qmf1ouGZcxBegEWodVy5fjFYFgQaB7wzw7j5rHwLcKeSXB|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|
+|Matic (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet|Qmf3igvJs24gozdwCwnDyPNz9DEBQMPQRFmEhUzEvgxZSq|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|
+|Matic Temp (Hosted Services)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet-temp|QmXyrt3tNkrnDRopnMdY7Na9y8jbKi1645gbR4cJTURbk5|QmUCo2VWg5Cj8C46nS1LNVemLbiXPcf2ad75d3dMrhdpJv|
+|Mumbai (Satsuma)|https://subgraph.satsuma-prod.com/decentraland/collections-matic-mumbai/playground|QmeSvj8AMGwFcQSoDdbMnB1SrVhrhAYq2DaUukEdMDpZ3v|QmQRwsc2CCebd4KVHNVeTcLZacqc3PGU5gt6yEo1n19x7L|
+|Mumbai (Hosted Service)|https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mumbai|QmdwRWh1FeGi3bJFYkD1Hu8w2uHvAHzJqbdCtszymfoqDS|QmQRwsc2CCebd4KVHNVeTcLZacqc3PGU5gt6yEo1n19x7L|
 
 Using [The Graph](https://thegraph.com) and [Satsuma](https://www.satsuma.xyz/)
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -278,6 +278,7 @@ type Order @entity {
   id: ID!
   marketplaceAddress: Bytes!
   nft: NFT
+  item: Item
   nftAddress: Bytes!
   tokenId: BigInt!
   txHash: Bytes!

--- a/src/entities/schema.ts
+++ b/src/entities/schema.ts
@@ -1895,6 +1895,23 @@ export class Order extends Entity {
     }
   }
 
+  get item(): string | null {
+    let value = this.get("item");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toString();
+    }
+  }
+
+  set item(value: string | null) {
+    if (!value) {
+      this.unset("item");
+    } else {
+      this.set("item", Value.fromString(<string>value));
+    }
+  }
+
   get nftAddress(): Bytes {
     let value = this.get("nftAddress");
     return value!.toBytes();

--- a/src/handlers/marketplace.ts
+++ b/src/handlers/marketplace.ts
@@ -21,6 +21,7 @@ export function handleOrderCreated(event: OrderCreated): void {
   order.marketplaceAddress = event.address
   order.status = status.OPEN
   order.nft = nftId
+  order.item = nft.item
   order.nftAddress = event.params.nftAddress
   order.tokenId = event.params.assetId
   order.txHash = event.transaction.hash

--- a/src/handlers/marketplaceV2.ts
+++ b/src/handlers/marketplaceV2.ts
@@ -21,6 +21,7 @@ export function handleOrderCreated(event: OrderCreated): void {
   order.marketplaceAddress = event.address
   order.status = status.OPEN
   order.nft = nftId
+  order.item = nft.item
   order.nftAddress = event.params.nftAddress
   order.tokenId = event.params.assetId
   order.txHash = event.transaction.hash


### PR DESCRIPTION
## Reason of this change

In order to be able to find orders for items faster, we can add the field `item` and therefore avoid joining the nfts table (when crafting the catalog SQL query for the unified market initiative) 

## TODO after deployment: update hashes