### PR TITLE
fix: patch buyer in sales done by third party providers

### DIFF
--- a/src/modules/analytics/index.ts
+++ b/src/modules/analytics/index.ts
@@ -20,10 +20,8 @@ import {
 
 // check if the buyer in a sale was a third party provider (to pay with credit card, cross chain, etc)
 export function isThirdPartySale(buyer: string): boolean {
-  switch (buyer) {
-    case '0xed038688ecf1193f8d9717eb3930f0bf0d745cb4': // TRANSAK POLYGON
-    case '0xea749fd6ba492dbc14c24fe8a3d08769229b896c': // AXELAR POLYGON & ETHEREUM
-      return true
+  if (buyer == '0xed038688ecf1193f8d9717eb3930f0bf0d745cb4' || buyer == '0xea749fd6ba492dbc14c24fe8a3d08769229b896c') {
+    return true
   }
   return false
 }

--- a/src/modules/analytics/index.ts
+++ b/src/modules/analytics/index.ts
@@ -22,6 +22,7 @@ import {
 export function isThirdPartySale(buyer: string): boolean {
   switch (buyer) {
     case '0xed038688ecf1193f8d9717eb3930f0bf0d745cb4': // TRANSAK POLYGON
+    case '0xea749fd6ba492dbc14c24fe8a3d08769229b896c': // AXELAR POLYGON
       return true
   }
   return false

--- a/src/modules/analytics/index.ts
+++ b/src/modules/analytics/index.ts
@@ -22,7 +22,7 @@ import {
 export function isThirdPartySale(buyer: string): boolean {
   switch (buyer) {
     case '0xed038688ecf1193f8d9717eb3930f0bf0d745cb4': // TRANSAK POLYGON
-    case '0xea749fd6ba492dbc14c24fe8a3d08769229b896c': // AXELAR POLYGON
+    case '0xea749fd6ba492dbc14c24fe8a3d08769229b896c': // AXELAR POLYGON & ETHEREUM
       return true
   }
   return false


### PR DESCRIPTION
Update the buyer of a sale with the `ownerOf(nft.tokenId)` when the sale was done by third party providers (Transak, Axelar, Wert).