### PR TITLE
fix: Update field updatedAt for collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 | Mainnet    | Hosted Services | https://thegraph.com/explorer/subgraph/decentraland/collections-ethereum-mainnet        | QmQVuFfc5quYrG7t4jVPRTNXjBWhPrqVtwwKkGrWoqnSHw | Qmf4SMTepdDoFh1ozcaAUMieGF83tnNa2G2Jr4KkH5jPRA |
 | Sepolia    | Satsuma         | https://subgraph.satsuma-prod.com/decentraland/collections-ethereum-sepolia/playground  | Qme5ou2ivyxTsosbmK5W5RWzpNmtDZFSqpGzDxpJUrdbhj | QmSYyRTthY69mSHxkAY6ym3beCWQr97NwecWdpxjiHypKh |
 | Sepolia    | Graph Studio    | https://api.studio.thegraph.com/query/49472/collections-ethereum-sepolia/version/latest | QmSYyRTthY69mSHxkAY6ym3beCWQr97NwecWdpxjiHypKh | QmWQZiMSV5AnUPN34NFmAYtxGntxewMUUwuS9r5vBpc5Ys |
-| Matic      | Satsuma         | https://subgraph.satsuma-prod.com/decentraland/collections-matic-mainnet/playground     | QmTmqmgdZ58JRp5N7nKj2XiE4b6R2HjsPNeMmbtU92Uc2x | QmTNHaULmSpzSsaMnFvUDqSpHUw7o5hGS7oGxj5hQo8pwX |
+| Matic      | Satsuma         | https://subgraph.satsuma-prod.com/decentraland/collections-matic-mainnet/playground     | QmQFB7Li2kPn51FisuV4UtVhyyyQ1wAkmnkoXKjYrLMCBP | QmTmqmgdZ58JRp5N7nKj2XiE4b6R2HjsPNeMmbtU92Uc2x |
 | Matic      | Graph Studio    | https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet           | Qmddr5gN7TY67SVZQzqGKSgwz3boofKdcnDD7QxSopraHV | QmTNHaULmSpzSsaMnFvUDqSpHUw7o5hGS7oGxj5hQo8pwX |
 | Matic Temp | Hosted Services | https://thegraph.com/explorer/subgraph/decentraland/collections-matic-mainnet-temp      | QmTKztw187jUHZ33S2pndtyo68K462XwewcvMVAVH7mwZR | Qmf3igvJs24gozdwCwnDyPNz9DEBQMPQRFmEhUzEvgxZSq |
-| Amoy       | Satsuma         | https://subgraph.satsuma-prod.com/decentraland/collections-matic-amoy/playground        | Qmd3Fxkiv9gWH87sWiNDaagU61mns77MizCMoKNDmhqbhK | QmeJBtfn5mgPH2CbRJpWbwUBmjg64vxTA5KTERaHUtG15u |
+| Amoy       | Satsuma         | https://subgraph.satsuma-prod.com/decentraland/collections-matic-amoy/playground        | QmTcuNd9C76Wj5L7tMA2Vm2d1WRxm5ME8Jf4uKPZgGC788 | Qmd3Fxkiv9gWH87sWiNDaagU61mns77MizCMoKNDmhqbhK |
 
 Using [The Graph](https://thegraph.com) and [Alchemy](https://www.alchemy.com/)
 

--- a/src/handlers/collection.ts
+++ b/src/handlers/collection.ts
@@ -576,6 +576,7 @@ export function handleTransferCreatorship(event: CreatorshipTransferred): void {
       let item = Item.load(itemId)
       if (item != null) {
         item.creator = newCreator
+        item.updatedAt = event.block.timestamp
         item.save()
       }
     }

--- a/src/handlers/collection.ts
+++ b/src/handlers/collection.ts
@@ -579,6 +579,7 @@ export function handleTransferCreatorship(event: CreatorshipTransferred): void {
         item.save()
       }
     }
+    collection.updatedAt = event.block.timestamp
     collection.save()
   }
 }
@@ -587,6 +588,7 @@ export function handleTransferOwnership(event: OwnershipTransferred): void {
   let collection = Collection.load(event.address.toHexString())
   if (collection != null) {
     collection.owner = event.params.newOwner.toHexString()
+    collection.updatedAt = event.block.timestamp
     collection.save()
   }
 }


### PR DESCRIPTION
This PR updates the collections `updatedAt` field when events `transferCreatorship` or `transferOwnership` are detected in the blockchain.